### PR TITLE
Support a custom model field

### DIFF
--- a/codemirror/fields.py
+++ b/codemirror/fields.py
@@ -1,0 +1,26 @@
+from django.db import models
+from django import forms
+
+from codemirror.widgets import CodeMirrorTextarea
+
+
+class CodeMirrorField(models.TextField):
+    def formfield(self, **kwargs):
+        defaults = {
+            'form_class': CodeMirrorFormField,
+        }
+        defaults.update(kwargs)
+        return super(CodeMirrorField, self).formfield(**defaults)
+
+
+class CodeMirrorFormField(forms.fields.Field):
+    def __init__(self, *args, **kwargs):
+        kwargs.update({'widget': CodeMirrorTextarea})
+        super(CodeMirrorFormField, self).__init__(*args, **kwargs)
+
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["^codemirror\.fields\.CodeMirrorField"])
+except:
+    pass
+


### PR DESCRIPTION
This allows you to directly tie the CodeMirorTextarea widget to a model field, which is helpful when you want to associate the widget from your model.

Example:

``` python
from codemirror.fields import CodeMirrorField

class PostChangeHook(models.Model):
    name = models.CharField(max_length=200,)
    function = CodeMirrorField(max_length=3000,)
```
