### PR TITLE
Added support for addons, keymaps, custom modes, and key handlers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,13 +18,13 @@ How to Use
 	``CODEMIRROR_PATH`` is the URI of CodeMirror directory like ``CODEMIRROR_PATH = r"javascript/codemirror"``.
 	If you don't specify it, it defaults to ``'codemirror'``.
 	CodeMirror should be put there.
-2.	Use ``codemirror.widgets.CodeMirrorTextarea`` widgets for target Textarea like below::
-	
-		from django import forms
-		from codemirror.widgets import CodeMirrorTextarea
+2.	Use ``codemirror.CodeMirrorTextarea`` widget for target Textarea like below::
 
-		codemirror = CodeMirrorTextarea(mode="python", theme="cobalt", config={ 'fixedGutter': True })
-		document = forms.TextField(widget=codemirror)
+		from django import forms
+		from codemirror import CodeMirrorTextarea
+
+		codemirror_widget = CodeMirrorTextarea(mode="python", theme="cobalt", config={ 'fixedGutter': True })
+		document = forms.TextField(widget=codemirror_widget)
 
 
 Settings

--- a/codemirror/__init__.py
+++ b/codemirror/__init__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
 u"""
-Library for using `CodeMirror` in Django
+Library for using `CodeMirror` in Django.
 """
+from codemirror.fields import CodeMirrorField, CodeMirrorFormField
+from codemirror.utils import CodeMirrorJavascript
+from codemirror.widgets import CodeMirrorTextarea

--- a/codemirror/utils.py
+++ b/codemirror/utils.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+Common utilities for codemirror module.
+"""
+
+import hashlib
+import json
+
+
+def isstring(obj):
+    try:
+        return isinstance(obj, basestring)
+    except NameError:
+        return isinstance(obj, str)
+
+
+class CodeMirrorJavascript(object):
+    """An object used to mark Javascript sections in JSON output.
+
+    If an object of this type is passed to CodeMirrorJSONEncoder().encode(), the text
+    containined in it will be output with no transformations applied. Most likely this
+    will not be valid JSON, but it will be valid Javascript, assuming valid Javascript
+    was passed to the constructor.
+
+    Example usage:
+
+    my_data = {
+        'someKey': True,
+        'someCallback': CodeMirrorJavascript("function() { return true; }")
+    }
+
+    CodeMirrorJSONEncoder().encode(my_data)
+
+    # -> '{"someKey": true, "someCallback": function() { return true; }}'
+    """
+
+    def __init__(self, js):
+        "js is a string containing valid Javascript code."
+        self.js = js
+
+
+class CodeMirrorJSONEncoder(json.JSONEncoder):
+    "A custom JSON encoder that knows how to handle CodeMirrorJavascript() objects."
+
+    stash_prefix = "js_stash::"
+
+    def __init__(self, *args, **kwargs):
+        super(CodeMirrorJSONEncoder, self).__init__(*args, **kwargs)
+        self.stash = {}
+
+    def default(self, obj):
+        if isinstance(obj, CodeMirrorJavascript):
+            # If a Javascript object is encountered, replace it with a placeholder.
+            stash_id = self.stash_prefix + hashlib.md5(obj.js).hexdigest()
+            self.stash[stash_id] = obj.js
+            return stash_id
+        return super(CodeMirrorJSONEncoder, self).default(obj)
+
+    def encode(self, obj):
+        self.stash = {}
+        encoded = super(CodeMirrorJSONEncoder, self).encode(obj)
+        # Search for any placeholders and replace them with their original values.
+        for key, val in self.stash.items():
+            encoded = encoded.replace('"' + key + '"', val)
+        self.stash = {}
+        return encoded


### PR DESCRIPTION
I've been using your plugin and have found it very helpful and easy to use. During the course of my integration, there were several features available in CodeMirror that were not possible with django-codemirror-widget. Namely, there was no way to use addons, keymaps, custom key handlers or custom modes. I took the liberty of adding these configuration options in my own branch, and have been using it quite successfully.

I also did a little reorganization to make this module's API more similar to Django's own `forms` module. So, it's now possible to import all the relevant classes directly from `codemirror` (e.g. `import codemirror.CodeMirrorTextarea` instead of `import codemirror.widgets.CodeMirrorTextarea`). Of course, it's still possible to import the old way.

This pull request should be fully backwards compatible with the last release. It would also close out issue #13.

I haven't exposed all the new widget configuration options via `settings`, since there are quite a few of them. This would be easy to add, though.
